### PR TITLE
Support Active Support 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rvm:
 gemfile:
 - gemfiles/activesupport42.gemfile
 - gemfiles/activesupport50.gemfile
+- gemfiles/activesupport51.gemfile
+- gemfiles/activesupport52.gemfile
 - gemfiles/activesupport_master.gemfile
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### v1.13.2
 - Bump active_utils to 3.3.1
-- Allow activesupport <5.2.0
+- Allow activesupport <5.3.0
 
 ### v1.13.1
 - Fix up UPS tracker parsing for Kosovo (KV)

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "<= 5.2.0.beta2")
+  s.add_dependency("activesupport", ">= 4.2", "<= 5.3.0")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 5.2.0")
+  s.add_dependency("activesupport", ">= 4.2", "<= 5.2.0.beta2")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/gemfiles/activesupport51.gemfile
+++ b/gemfiles/activesupport51.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 5.1.0'
+gem 'active_utils', '~> 3.3.0'

--- a/gemfiles/activesupport52.gemfile
+++ b/gemfiles/activesupport52.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'activesupport', '5.2.0.beta2'
+gem 'activesupport', '5.3.0'
 gem 'active_utils', '~> 3.3.0'

--- a/gemfiles/activesupport52.gemfile
+++ b/gemfiles/activesupport52.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'activesupport', '5.3.0'
+gem 'activesupport', '<= 5.3.0'
 gem 'active_utils', '~> 3.3.0'

--- a/gemfiles/activesupport52.gemfile
+++ b/gemfiles/activesupport52.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'activesupport', '5.2.0.beta2'
+gem 'active_utils', '~> 3.3.0'


### PR DESCRIPTION
### Problems

- Active Shipping master removed support for UPS. See https://github.com/Shopify/active_shipping/commit/20da5553db136b980810cbedd5d62f7e45bda419
- Active Shipping does not support rails 5.2


### Solutions

- I made PopularPays/active_shipping#master branch reflect what we currently use in production. (v2.1.1) which has support for UPS
- This p.r. adds support for rails 5.2

Unit tests pass locally. 

Confirmed it bundles with rails 5.2 and 4.2.

Remote tests in this repo are bit messy because they require login credentials. Before deploying this with ppsuite I plan on manually testing that we can hit the api for FedEx, UPS, USPS from console.

----
card: https://trello.com/c/NnPqfKJf/143-make-activeshipping-gem-support-rails-52